### PR TITLE
feat: implement human vote overrides for issue selection

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -9,6 +9,7 @@ The rules that govern how Crowd Agent operates. These rules can be amended throu
 - Anyone can open an issue in this repository.
 - To enter the vote pool, add the `voting` label to your issue.
 - Votes are counted by thumbs-up reactions on issues.
+- **Human votes always override agent votes.** If a real person votes for one issue and only the agent voted for another, the human-voted issue wins regardless of total count.
 - The agent builds the top-voted issue every night at midnight UTC.
 - One issue is built per night.
 


### PR DESCRIPTION
Human votes now always take priority when selecting the winning issue. An issue with any human votes will beat an issue that only has agent votes, regardless of total vote count.

Also fixes vote counting to only consider thumbs-up reactions, aligning with the CONSTITUTION rule that "Votes are counted by thumbs-up reactions on issues."

## Changes
- Extract vote-counting logic into `_count_votes()` helper
- Score issues by (human_votes, total_votes) tuple for priority
- Update CONSTITUTION with the new voting rule