### PR TITLE
Fix: Use GH_PAT for pushes to trigger workflows

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run agent
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GH_PAT: ${{ secrets.GH_PAT }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}

--- a/agent/main.py
+++ b/agent/main.py
@@ -200,7 +200,7 @@ def execute_tool_safely(tool_name: str, tool_input: dict) -> str:
 # --- GitHub Helpers ---
 
 def get_github() -> Github:
-    token = os.environ["GITHUB_TOKEN"]
+    token = os.environ.get("GITHUB_TOKEN", os.environ.get("GH_PAT", ""))
     return Github(auth=Auth.Token(token))
 
 def get_repo(gh: Github):
@@ -278,8 +278,8 @@ def create_branch_and_pr(repo, issue, changes: dict[str, str], changelog_text: s
     commit_msg = f"feat: implement #{issue.number} — {issue.title}"
     run_git("commit", "-m", commit_msg)
 
-    # Push using the GITHUB_TOKEN
-    token = os.environ["GITHUB_TOKEN"]
+    # Push using the GH_PAT (personal access token) so it can trigger other workflows
+    token = os.environ.get("GH_PAT", os.environ["GITHUB_TOKEN"])
     owner = os.environ.get("REPO_OWNER", "trevorstenson")
     name = os.environ.get("REPO_NAME", "crowd-agent")
     remote_url = f"https://x-access-token:{token}@github.com/{owner}/{name}.git"


### PR DESCRIPTION
Separates the personal access token (GH_PAT) from the built-in GITHUB_TOKEN so that PR creation can use the PAT for push operations.

GitHub's built-in GITHUB_TOKEN deliberately cannot trigger other workflows to prevent infinite loops. This change allows the agent to use the PAT specifically for pushes that need to trigger downstream workflow runs.

Changes:
- Update nightly-build.yml to pass GH_PAT as its own env var instead of masking GITHUB_TOKEN
- Update agent/main.py to prefer GH_PAT for push operations while falling back to GITHUB_TOKEN for general API calls