### PR TITLE
revert: switch back to Claude from Groq Llama 3.1 8B

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run agent
         env:
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_PAT: ${{ secrets.GH_PAT }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}

--- a/agent/config.json
+++ b/agent/config.json
@@ -1,5 +1,5 @@
 {
-  "model": "llama-3.1-8b-instant",
+  "model": "claude-haiku-4-5-20251001",
   "max_tokens": 8096,
   "max_turns": 10,
   "temperature": 0,

--- a/agent/main.py
+++ b/agent/main.py
@@ -4,8 +4,8 @@ Crowd Agent — The Evolving Build Loop
 This script runs nightly via GitHub Actions. It:
 1. Finds the top-voted issue labeled 'voting'
 2. Announces the build on the issue
-3. Calls the Groq API to create a plan
-4. Calls the Groq API with tool use to implement the plan
+3. Calls the Claude API to create a plan
+4. Calls the Claude API with tool use to implement the plan
 5. Creates a branch and PR with the changes
 6. Reports the result
 
@@ -23,7 +23,7 @@ from datetime import datetime, timezone
 from functools import wraps
 from typing import Optional
 
-import openai
+import anthropic
 from github import Auth, Github
 from tenacity import (
     retry,
@@ -117,7 +117,7 @@ def classify_api_error(exception: Exception) -> str:
 # --- Retry Decorators ---
 
 def retry_on_transient_api_error(func):
-    """Decorator to retry API calls on transient failures with exponential backoff."""
+    """Decorator to retry Claude API calls on transient failures with exponential backoff."""
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=2, min=1, max=30),
@@ -281,7 +281,7 @@ def create_branch_and_pr(repo, issue, changes: dict[str, str], changelog_text: s
     run_git("commit", "-m", commit_msg)
 
     # Push using the GH_PAT (personal access token) so it can trigger other workflows
-    token = os.environ.get("GH_PAT") or os.environ.get("GITHUB_TOKEN", "")
+    token = os.environ.get("GH_PAT", os.environ["GITHUB_TOKEN"])
     owner = os.environ.get("REPO_OWNER", "trevorstenson")
     name = os.environ.get("REPO_NAME", "crowd-agent")
     remote_url = f"https://x-access-token:{token}@github.com/{owner}/{name}.git"
@@ -338,10 +338,7 @@ def report_failure(repo, issue, error: str):
 
 def generate_changelog_entry(config, issue, changes: dict[str, str], success: bool, error: str | None = None) -> str:
     """Ask the agent to write a changelog entry. Returns the formatted markdown entry."""
-    client = openai.OpenAI(
-        base_url="https://api.groq.com/openai/v1",
-        api_key=os.environ.get("GROQ_API_KEY"),
-    )
+    client = anthropic.Anthropic()
 
     if success:
         prompt = (
@@ -367,14 +364,14 @@ def generate_changelog_entry(config, issue, changes: dict[str, str], success: bo
             "Return ONLY the entry text, no heading or date."
         )
 
-    response = client.chat.completions.create(
+    response = client.messages.create(
         model=config["model"],
         max_tokens=300,
         temperature=0.7,
         messages=[{"role": "user", "content": prompt}],
     )
 
-    entry_text = response.choices[0].message.content.strip()
+    entry_text = response.content[0].text.strip()
     date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     status_emoji = "+" if success else "x"
 
@@ -436,11 +433,8 @@ def vote_on_next_issue(repo, config, just_built_number: int):
         '{"issue_number": <number>, "reason": "<1-2 sentence explanation>"}'
     )
 
-    client = openai.OpenAI(
-        base_url="https://api.groq.com/openai/v1",
-        api_key=os.environ.get("GROQ_API_KEY"),
-    )
-    response = client.chat.completions.create(
+    client = anthropic.Anthropic()
+    response = client.messages.create(
         model=config["model"],
         max_tokens=256,
         temperature=0,
@@ -448,7 +442,7 @@ def vote_on_next_issue(repo, config, just_built_number: int):
     )
 
     try:
-        text = response.choices[0].message.content.strip()
+        text = response.content[0].text.strip()
         # Strip markdown fencing if the model wraps the JSON
         if text.startswith("```"):
             text = text.split("\n", 1)[1] if "\n" in text else text[3:]
@@ -471,7 +465,7 @@ def vote_on_next_issue(repo, config, just_built_number: int):
         print(f"Agent chose issue #{chosen_number} but it wasn't found in the pool.")
     except Exception as e:
         print(f"Warning: Could not vote on next issue: {e}")
-        print(f"Raw response: {response.choices[0].message.content[:500] if response.choices else '(empty)'}")
+        print(f"Raw response: {response.content[0].text[:500] if response.content else '(empty)'}")
 
 
 def run_git(*args):
@@ -516,16 +510,13 @@ def get_repo_file_list() -> list[str]:
 
 @retry_on_transient_api_error
 def create_plan(issue, repo_files: list[str], config: dict) -> str:
-    """Ask the LLM to create a plan for implementing the issue.
-
+    """Ask Claude to create a plan for implementing the issue.
+    
     Returns the plan as a string.
     Retries on transient API errors.
     """
-    client = openai.OpenAI(
-        base_url="https://api.groq.com/openai/v1",
-        api_key=os.environ.get("GROQ_API_KEY"),
-    )
-
+    client = anthropic.Anthropic()
+    
     prompt = (
         f"## Task\n\nCreate a detailed plan for implementing this GitHub issue:\n\n"
         f"**#{issue.number}: {issue.title}**\n\n{issue.body or '(no description)'}\n\n"
@@ -545,28 +536,25 @@ def create_plan(issue, repo_files: list[str], config: dict) -> str:
         "Be specific and concrete. This plan will guide your implementation."
     )
     
-    response = client.chat.completions.create(
+    response = client.messages.create(
         model=config["model"],
         max_tokens=2000,
         temperature=0.3,
         messages=[{"role": "user", "content": prompt}],
     )
-
-    plan = response.choices[0].message.content.strip()
+    
+    plan = response.content[0].text.strip()
     print(f"Plan created:\n{plan[:500]}...\n")
     return plan
 
 def run_agent(issue, repo_files: list[str], config: dict, system_prompt: str, plan: str) -> dict[str, str]:
-    """Run the agent loop: call the LLM with tools until done. Returns file changes.
-
+    """Run the agent loop: call Claude with tools until done. Returns file changes.
+    
     The agent is given the plan upfront to guide its implementation.
     Includes timeout protection and graceful error handling for tool execution.
     """
     reset_file_changes()
-    client = openai.OpenAI(
-        base_url="https://api.groq.com/openai/v1",
-        api_key=os.environ.get("GROQ_API_KEY"),
-    )
+    client = anthropic.Anthropic()
     error_config = config.get("error_handling", {})
     timeout_seconds = error_config.get("agent_loop_timeout_seconds", 300)
 
@@ -578,82 +566,64 @@ def run_agent(issue, repo_files: list[str], config: dict, system_prompt: str, pl
     )
 
     messages = [
-        {"role": "system", "content": system_prompt},
-        {"role": "user", "content": prompt_text},
+        {"role": "user", "content": prompt_text}
     ]
 
     with TimeoutHandler(timeout_seconds) as timeout_handler:
         for turn in range(config["max_turns"]):
             # Check timeout before each turn
             timeout_handler.check()
-
+            
             print(f"--- Agent turn {turn + 1}/{config['max_turns']} ---")
 
             try:
-                response = client.chat.completions.create(
+                response = client.messages.create(
                     model=config["model"],
                     max_tokens=config["max_tokens"],
                     temperature=config["temperature"],
+                    system=system_prompt,
                     messages=messages,
                     tools=TOOL_DEFINITIONS,
                 )
-            except openai.RateLimitError as e:
+            except anthropic.RateLimitError as e:
                 logger.warning(f"Rate limit error on turn {turn + 1}, retrying: {e}")
                 time.sleep(2)
                 continue
-            except openai.APITimeoutError as e:
+            except anthropic.APITimeoutError as e:
                 logger.warning(f"API timeout on turn {turn + 1}, retrying: {e}")
                 time.sleep(2)
                 continue
-            except openai.BadRequestError as e:
-                if "tool_use_failed" in str(e):
-                    logger.warning(f"Model generated malformed tool call on turn {turn + 1}, retrying")
-                    messages.append({
-                        "role": "user",
-                        "content": "Your previous tool call was malformed. Use the provided tools correctly by passing proper JSON arguments.",
-                    })
-                    continue
-                logger.error(f"API error on turn {turn + 1}: {e}")
-                raise
-            except openai.APIError as e:
+            except anthropic.APIError as e:
                 logger.error(f"API error on turn {turn + 1}: {e}")
                 raise
 
-            message = response.choices[0].message
-            messages.append(message)
+            # Collect assistant content
+            assistant_content = response.content
+            messages.append({"role": "assistant", "content": assistant_content})
 
             # Check if done
-            if response.choices[0].finish_reason == "stop":
-                if message.content:
-                    print(f"Agent summary: {message.content[:200]}...")
-                break
-
-            if response.choices[0].finish_reason == "length":
-                logger.warning("Response truncated (max_tokens reached), stopping agent.")
+            if response.stop_reason == "end_turn":
+                # Extract final text
+                for block in assistant_content:
+                    if hasattr(block, "text"):
+                        print(f"Agent summary: {block.text[:200]}...")
                 break
 
             # Process tool calls
-            if message.tool_calls:
-                for tool_call in message.tool_calls:
-                    name = tool_call.function.name
-                    try:
-                        args = json.loads(tool_call.function.arguments)
-                    except json.JSONDecodeError as e:
-                        logger.warning(f"Malformed tool call arguments from model: {e}")
-                        messages.append({
-                            "role": "tool",
-                            "tool_call_id": tool_call.id,
-                            "content": f"Error: Your tool call had invalid JSON arguments: {e}. Please retry with valid JSON.",
-                        })
-                        continue
-                    print(f"  Tool call: {name}({json.dumps(args)[:100]})")
-                    result = execute_tool_safely(name, args)
+            tool_results = []
+            for block in assistant_content:
+                if block.type == "tool_use":
+                    print(f"  Tool call: {block.name}({json.dumps(block.input)[:100]})")
+                    result = execute_tool_safely(block.name, block.input)
                     print(f"  Result: {result[:100]}...")
-                    messages.append({
-                        "role": "tool",
-                        "tool_call_id": tool_call.id,
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
                         "content": result,
                     })
+
+            if tool_results:
+                messages.append({"role": "user", "content": tool_results})
         else:
             logger.warning("Agent reached max turns without finishing.")
 
@@ -706,7 +676,7 @@ def main():
         except RetryError as e:
             raise RuntimeError(f"Failed to create plan after max retries: {e}")
 
-        # Step 5-6: Run the agent loop with the plan
+        # Step 5-6: Run the agent loop with the plan (calls Claude, executes tools)
         try:
             changes = run_agent(issue, repo_files, config, system_prompt, plan)
         except AgentLoopTimeout as e:

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -134,86 +134,77 @@ def search_files(pattern: str, case_sensitive: bool = False, max_results: int = 
     })
 
 
-# Tool definitions for the OpenAI-compatible API (Groq)
+# Tool definitions for the Claude API
 TOOL_DEFINITIONS = [
     {
-        "type": "function",
-        "function": {
-            "name": "read_file",
-            "description": "Read the contents of a file in the repository.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Path to the file relative to the repository root."
-                    }
-                },
-                "required": ["path"]
-            }
+        "name": "read_file",
+        "description": "Read the contents of a file in the repository.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file relative to the repository root."
+                }
+            },
+            "required": ["path"]
         }
     },
     {
-        "type": "function",
-        "function": {
-            "name": "write_file",
-            "description": "Write or overwrite a file in the repository.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Path to the file relative to the repository root."
-                    },
-                    "content": {
-                        "type": "string",
-                        "description": "The full content to write to the file."
-                    }
+        "name": "write_file",
+        "description": "Write or overwrite a file in the repository.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file relative to the repository root."
                 },
-                "required": ["path", "content"]
-            }
+                "content": {
+                    "type": "string",
+                    "description": "The full content to write to the file."
+                }
+            },
+            "required": ["path", "content"]
         }
     },
     {
-        "type": "function",
-        "function": {
-            "name": "list_files",
-            "description": "List files and directories in a given directory.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "directory": {
-                        "type": "string",
-                        "description": "Path to the directory relative to the repository root. Defaults to root."
-                    }
-                },
-                "required": []
-            }
+        "name": "list_files",
+        "description": "List files and directories in a given directory.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "directory": {
+                    "type": "string",
+                    "description": "Path to the directory relative to the repository root. Defaults to root.",
+                    "default": "."
+                }
+            },
+            "required": []
         }
     },
     {
-        "type": "function",
-        "function": {
-            "name": "search_files",
-            "description": "Search for text patterns across the repository. Useful for discovering relevant code when you don't know the exact file location.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "pattern": {
-                        "type": "string",
-                        "description": "Text or regex pattern to search for. Supports regex syntax."
-                    },
-                    "case_sensitive": {
-                        "type": "boolean",
-                        "description": "Whether to match case. Default is false (case-insensitive)."
-                    },
-                    "max_results": {
-                        "type": "integer",
-                        "description": "Maximum number of results to return. Default is 20."
-                    }
+        "name": "search_files",
+        "description": "Search for text patterns across the repository. Useful for discovering relevant code when you don't know the exact file location.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Text or regex pattern to search for. Supports regex syntax."
                 },
-                "required": ["pattern"]
-            }
+                "case_sensitive": {
+                    "type": "boolean",
+                    "description": "Whether to match case. Default is false (case-insensitive).",
+                    "default": False
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return. Default is 20.",
+                    "default": 20
+                }
+            },
+            "required": ["pattern"]
         }
     }
 ]
@@ -232,9 +223,9 @@ def execute_tool(name: str, inputs: dict) -> str:
     if name not in TOOL_FUNCTIONS:
         return f"Error: Unknown tool: {name}"
     # Validate and filter inputs against schema
-    schema = next(t for t in TOOL_DEFINITIONS if t["function"]["name"] == name)
-    valid_keys = set(schema["function"]["parameters"].get("properties", {}).keys())
-    required_keys = set(schema["function"]["parameters"].get("required", []))
+    schema = next(t for t in TOOL_DEFINITIONS if t["name"] == name)
+    valid_keys = set(schema["input_schema"].get("properties", {}).keys())
+    required_keys = set(schema["input_schema"].get("required", []))
     filtered = {k: v for k, v in inputs.items() if k in valid_keys}
     missing = required_keys - set(filtered.keys())
     if missing:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openai>=1.0.0
+anthropic>=0.40.0
 PyGithub>=2.1.0
 tweepy>=4.14.0
 tenacity>=8.2.0


### PR DESCRIPTION
## Summary
- Reverts the Groq/Llama migration (commits 2726bb8, 85b4f2a, e5003a8)
- Switches back to Claude Haiku 4.5 with the Anthropic SDK

## Why
Llama 3.1 8B on Groq is not reliable enough for the agent loop:
- Overwrites entire files with placeholder text like `"# New content here"`
- Produces malformed tool call arguments
- Hits Groq's free-tier 6K TPM limit by turn 3

## Test plan
- [ ] Trigger a nightly build and verify it completes successfully with Claude