### PR TITLE
fix: add token validation in nightly build workflow

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -15,6 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Check required tokens
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -z "$GH_PAT" ] && [ -z "$GITHUB_TOKEN" ]; then
+            echo "::error::Neither GH_PAT nor GITHUB_TOKEN is set. Skipping build."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
@@ -28,6 +38,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_PAT: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}

--- a/agent/main.py
+++ b/agent/main.py
@@ -281,7 +281,9 @@ def create_branch_and_pr(repo, issue, changes: dict[str, str], changelog_text: s
     run_git("commit", "-m", commit_msg)
 
     # Push using the GH_PAT (personal access token) so it can trigger other workflows
-    token = os.environ.get("GH_PAT", os.environ["GITHUB_TOKEN"])
+    token = os.environ.get("GH_PAT") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise RuntimeError("Neither GH_PAT nor GITHUB_TOKEN is set. Cannot push or create PR.")
     owner = os.environ.get("REPO_OWNER", "trevorstenson")
     name = os.environ.get("REPO_NAME", "crowd-agent")
     remote_url = f"https://x-access-token:{token}@github.com/{owner}/{name}.git"


### PR DESCRIPTION
## Summary
- Add preflight check in nightly-build.yml to fail early if neither GH_PAT nor GITHUB_TOKEN is set
- Pass GITHUB_TOKEN as fallback in the "Run agent" step environment
- Fix agent/main.py to use conditional logic instead of unsafe dict lookup, with clear error message

This prevents wasted build cycles when required tokens are missing.