### PR TITLE
fix: use GitHub App token for nightly builds

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -15,15 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Check required tokens
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -z "$GH_PAT" ] && [ -z "$GITHUB_TOKEN" ]; then
-            echo "::error::Neither GH_PAT nor GITHUB_TOKEN is set. Skipping build."
-            exit 1
-          fi
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
 
@@ -37,8 +34,7 @@ jobs:
       - name: Run agent
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_PAT: ${{ secrets.GH_PAT }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ steps.app-token.outputs.token }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
@@ -50,7 +46,7 @@ jobs:
       - name: Report failure
         if: failure()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh issue create \
             --title "Nightly build failure — $(date -u +%Y-%m-%d)" \


### PR DESCRIPTION
## Summary
- Replace `GH_PAT` secret with a GitHub App installation token via `actions/create-github-app-token@v1`
- PRs and issues will now come from the bot app instead of a personal account, allowing the repo owner to review them
- Requires `APP_ID` and `APP_PRIVATE_KEY` secrets to be configured in the repo